### PR TITLE
Add timestamped consumption and diagnostic sensors

### DIFF
--- a/custom_components/quandify/api.py
+++ b/custom_components/quandify/api.py
@@ -6,12 +6,13 @@ from typing import Any
 import aiohttp
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from .const import API_BASE_URL, AUTH_BASE_URL
 from .const import (
+    API_BASE_URL,
+    AUTH_BASE_URL,
     CONF_ACCOUNT_ID,
     CONF_ID_TOKEN,
-    CONF_REFRESH_TOKEN,
     CONF_ORGANIZATION_ID,
+    CONF_REFRESH_TOKEN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -69,11 +70,15 @@ class QuandifyAPI:
 
     async def _request(
         self, method: str, url: str, retry: bool = True, **kwargs: Any
-    ) -> dict[str, Any]:
-        """Make an authenticated request to the Quandify API, refreshing the token if needed."""
+    ) -> Any:
+        """Make an authenticated request to the Quandify API.
+
+        Different Quandify endpoints return different payload shapes. Keep this
+        helper generic and let the public API methods validate the response shape
+        they expect.
+        """
 
         headers = {"Authorization": f"Bearer {self._config.get(CONF_ID_TOKEN)}"}
-        response = {}
 
         try:
             response = await self.session.request(
@@ -121,13 +126,68 @@ class QuandifyAPI:
         organization_id = self._config.get(CONF_ORGANIZATION_ID)
         url = f"{API_BASE_URL}/organization/{organization_id}/devices/"
         response = await self._request("get", url)
-        return response.get("data", [])
+        return response.get("data", []) if isinstance(response, dict) else []
 
     async def get_device_info(self, device_id: str) -> dict[str, Any]:
         """Get all info for a single device."""
         organization_id = self._config.get(CONF_ORGANIZATION_ID)
         url = f"{API_BASE_URL}/organization/{organization_id}/devices/{device_id}"
-        return await self._request("get", url)
+        response = await self._request("get", url)
+        return response if isinstance(response, dict) else {}
+
+    async def get_device_detailed_consumption(
+        self,
+        device_id: str,
+        *,
+        from_ts: int,
+        to_ts: int,
+        truncate: str = "hour",
+        timezone: str = "UTC",
+    ) -> dict[str, Any]:
+        """Get detailed timestamped consumption for a single device.
+
+        The detailed response includes both timestamped consumption data and
+        aggregate totals for the requested period. This is the preferred source
+        for hourly water usage graphs.
+        Callers should pass the Home Assistant configured time zone when possible.
+        """
+        organization_id = self._config.get(CONF_ORGANIZATION_ID)
+        url = (
+            f"{API_BASE_URL}/organization/{organization_id}/devices/"
+            f"{device_id}/detailed-consumption"
+        )
+        params = {
+            "from": from_ts,
+            "to": to_ts,
+            "truncate": truncate,
+            "timezone": timezone,
+        }
+        response = await self._request("get", url, params=params)
+        return response if isinstance(response, dict) else {}
+
+    async def get_device_leak_status(self, device_id: str) -> dict[str, Any]:
+        """Get detailed leak status for a single device.
+
+        This exposes the API leak state, mean flow and timestamps in addition
+        to the basic leak binary sensor.
+        """
+        organization_id = self._config.get(CONF_ORGANIZATION_ID)
+        url = (
+            f"{API_BASE_URL}/organization/{organization_id}/devices/"
+            f"{device_id}/leak-status"
+        )
+        response = await self._request("get", url)
+        return response if isinstance(response, dict) else {}
+
+    async def get_device_firmware_version(self, device_id: str) -> dict[str, Any]:
+        """Get current and latest firmware version for a single device."""
+        organization_id = self._config.get(CONF_ORGANIZATION_ID)
+        url = (
+            f"{API_BASE_URL}/organization/{organization_id}/devices/"
+            f"{device_id}/firmware-version"
+        )
+        response = await self._request("get", url)
+        return response if isinstance(response, dict) else {}
 
     async def acknowledge_leak(self, device_id: str) -> None:
         """Acknowledge a leak."""

--- a/custom_components/quandify/const.py
+++ b/custom_components/quandify/const.py
@@ -19,3 +19,7 @@ CONF_ORGANIZATION_ID: Final = "organization_id"
 
 # Data Update Coordinator
 UPDATE_INTERVAL_MINUTES: Final = 10
+
+# Extended consumption data settings
+EXTENDED_CONSUMPTION_LOOKBACK_HOURS: Final = 24
+EXTENDED_CONSUMPTION_BUCKET_DELAY_MINUTES: Final = 5

--- a/custom_components/quandify/coordinator.py
+++ b/custom_components/quandify/coordinator.py
@@ -2,15 +2,20 @@
 
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import QuandifyAPI
-from .const import DOMAIN, UPDATE_INTERVAL_MINUTES
+from .const import (
+    DOMAIN,
+    EXTENDED_CONSUMPTION_LOOKBACK_HOURS,
+    UPDATE_INTERVAL_MINUTES,
+)
 from .models import QuandifyDevice
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,8 +41,65 @@ class QuandifyDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             async with asyncio.timeout(30):
                 data = {}
+
+                # Request the latest hourly buckets on the normal coordinator
+                # polling interval. Home Assistant's configured time zone is
+                # passed to the API so bucket timestamps match the local UI.
+                now_ts = int(datetime.now().timestamp())
+                from_ts = now_ts - EXTENDED_CONSUMPTION_LOOKBACK_HOURS * 60 * 60
+                timezone = self.hass.config.time_zone
+
                 for device in self.devices:
                     device_info = await self.api.get_device_info(device.id)
+
+                    # Keep optional endpoint failures isolated from the main
+                    # coordinator update. A temporary failure in historical
+                    # consumption or diagnostics should not make the device
+                    # unavailable in Home Assistant.
+                    extended_data: dict[str, Any] = {}
+
+                    try:
+                        extended_data["detailed_consumption_hourly"] = (
+                            await self.api.get_device_detailed_consumption(
+                                device.id,
+                                from_ts=from_ts,
+                                to_ts=now_ts,
+                                truncate="hour",
+                                timezone=timezone,
+                            )
+                        )
+                    except Exception as exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Failed to fetch detailed consumption for %s: %s",
+                            device.id,
+                            exception,
+                        )
+
+                    try:
+                        extended_data["leak_status"] = (
+                            await self.api.get_device_leak_status(device.id)
+                        )
+                    except Exception as exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Failed to fetch leak status for %s: %s",
+                            device.id,
+                            exception,
+                        )
+
+                    try:
+                        extended_data["firmware_version"] = (
+                            await self.api.get_device_firmware_version(device.id)
+                        )
+                    except Exception as exception:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Failed to fetch firmware version for %s: %s",
+                            device.id,
+                            exception,
+                        )
+
+                    if extended_data:
+                        device_info["quandify_extended"] = extended_data
+
                     data[device.id] = device_info
                 return data
         except Exception as exception:

--- a/custom_components/quandify/sensor.py
+++ b/custom_components/quandify/sensor.py
@@ -1,5 +1,8 @@
 """Sensor platform for Quandify integration."""
 
+from datetime import datetime, timedelta
+from typing import Any
+
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -14,8 +17,9 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
-from .const import DOMAIN
+from .const import DOMAIN, EXTENDED_CONSUMPTION_BUCKET_DELAY_MINUTES
 from .coordinator import QuandifyDataUpdateCoordinator
 from .entity import QuandifyEntity
 from .models import QuandifyDevice
@@ -26,47 +30,110 @@ TOTAL_VOLUME = SensorEntityDescription(
     name="Total volume",
     native_unit_of_measurement=UnitOfVolume.LITERS,
     state_class=SensorStateClass.TOTAL_INCREASING,
-    device_class=SensorDeviceClass.WATER)
+    device_class=SensorDeviceClass.WATER,
+)
 
 WATER_TEMP = SensorEntityDescription(
     key="status.avg_water_temp",
     name="Water temperature",
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     state_class=SensorStateClass.MEASUREMENT,
-    device_class=SensorDeviceClass.TEMPERATURE)
+    device_class=SensorDeviceClass.TEMPERATURE,
+)
 
 AMBIENT_TEMP = SensorEntityDescription(
     key="status.ambient_temp",
     name="Ambient temperature",
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     state_class=SensorStateClass.MEASUREMENT,
-    device_class=SensorDeviceClass.TEMPERATURE)
+    device_class=SensorDeviceClass.TEMPERATURE,
+)
 
 WIFI_SIGNAL = SensorEntityDescription(
     key="status.wifi_signal_strength",
     name="Signal strength",
     native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-    state_class=SensorStateClass.MEASUREMENT)
+    state_class=SensorStateClass.MEASUREMENT,
+)
 
 RSSI_SIGNAL = SensorEntityDescription(
     key="status.rssi",
     name="Signal strength",
     native_unit_of_measurement=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     device_class=SensorDeviceClass.SIGNAL_STRENGTH,
-    state_class=SensorStateClass.MEASUREMENT)
+    state_class=SensorStateClass.MEASUREMENT,
+)
 
 WATER_TYPE = SensorEntityDescription(
     key="sub_type",
     name="Water type",
-    icon="mdi:water-thermometer")
+    icon="mdi:water-thermometer",
+)
+
+LEAK_STATE = SensorEntityDescription(
+    key="quandify_extended.leak_status.leak_state",
+    name="Leak state",
+    icon="mdi:pipe-leak",
+)
+
+LEAK_MEAN_FLOW = SensorEntityDescription(
+    key="quandify_extended.leak_status.mean_flow_lph",
+    name="Leak mean flow rate",
+    native_unit_of_measurement="L/h",
+    state_class=SensorStateClass.MEASUREMENT,
+    icon="mdi:waves-arrow-right",
+)
+
+LEAK_UPDATED_AT = SensorEntityDescription(
+    key="quandify_extended.leak_status.updated_at",
+    name="Leak status updated",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    icon="mdi:clock-alert-outline",
+)
+
+CURRENT_FIRMWARE = SensorEntityDescription(
+    key="quandify_extended.firmware_version.currentVersion",
+    name="Current firmware",
+    icon="mdi:chip",
+)
+
+LATEST_FIRMWARE = SensorEntityDescription(
+    key="quandify_extended.firmware_version.latestVersion",
+    name="Latest firmware",
+    icon="mdi:update",
+)
+
+HOURLY_CONSUMPTION = SensorEntityDescription(
+    key="quandify_extended.detailed_consumption_hourly",
+    name="Latest hourly consumption",
+    native_unit_of_measurement=UnitOfVolume.LITERS,
+    state_class=SensorStateClass.MEASUREMENT,
+    icon="mdi:chart-bar",
+)
 
 # Sensor profiles
 DEVICE_SENSORS = {
-    "Water Grip": [TOTAL_VOLUME, WATER_TEMP, WIFI_SIGNAL, WATER_TYPE],
+    "Water Grip": [
+        TOTAL_VOLUME,
+        WATER_TEMP,
+        WIFI_SIGNAL,
+        WATER_TYPE,
+        LEAK_STATE,
+        LEAK_MEAN_FLOW,
+        LEAK_UPDATED_AT,
+        CURRENT_FIRMWARE,
+        LATEST_FIRMWARE,
+        HOURLY_CONSUMPTION,
+    ],
 }
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up the sensor entities."""
     coordinator: QuandifyDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[QuandifySensor] = []
@@ -77,10 +144,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
             )
     async_add_entities(entities)
 
+
 class QuandifySensor(QuandifyEntity, SensorEntity):
     """Implementation of a Quandify sensor."""
 
-    def __init__(self, coordinator: QuandifyDataUpdateCoordinator, device: QuandifyDevice, description: SensorEntityDescription):
+    def __init__(
+        self,
+        coordinator: QuandifyDataUpdateCoordinator,
+        device: QuandifyDevice,
+        description: SensorEntityDescription,
+    ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator, device)
         self.entity_description = description
@@ -103,12 +176,145 @@ class QuandifySensor(QuandifyEntity, SensorEntity):
         if self.entity_description.key == "sub_type":
             sub_type = value.get("sub_type")
             self._attr_native_value = sub_type.capitalize() if sub_type else None
+        elif self.entity_description.key == "quandify_extended.leak_status.updated_at":
+            timestamp = self._get_nested_value(value, self.entity_description.key)
+            self._attr_native_value = self._timestamp_to_datetime(timestamp)
+        elif self.entity_description.key == "quandify_extended.detailed_consumption_hourly":
+            detailed_consumption = self._get_nested_value(
+                value, self.entity_description.key
+            )
+            self._update_hourly_consumption(detailed_consumption)
         else:
+            self._attr_native_value = self._get_nested_value(
+                value, self.entity_description.key
+            )
+
+    @staticmethod
+    def _get_nested_value(data: dict[str, Any], key: str) -> Any:
+        """Get a nested value from a dictionary using a dot separated key."""
+        value: Any = data
+        try:
+            for key_part in key.split("."):
+                if value is None:
+                    break
+                value = value.get(key_part)
+        except AttributeError:
+            value = None
+        return value
+
+    @staticmethod
+    def _timestamp_to_datetime(timestamp: Any) -> datetime | None:
+        """Convert a Unix timestamp to a timezone-aware datetime."""
+        if timestamp in (None, "unknown", "unavailable", ""):
+            return None
+        try:
+            return dt_util.as_local(dt_util.utc_from_timestamp(float(timestamp)))
+        except (TypeError, ValueError):
+            return None
+
+    def _update_hourly_consumption(self, detailed_consumption: Any) -> None:
+        """Update hourly consumption sensor value and attributes.
+
+        The Quandify detailed consumption endpoint can return separate rows for
+        hot, cold and unknown water at the same timestamp. Group the latest 24
+        hourly buckets into a compact `hourly_total` attribute that is easier to
+        use for Home Assistant charts and small enough for the recorder.
+
+        The `datetime` field is kept as provided by the Quandify API. For easier
+        use in dashboards, the integration also exposes `bucket_start` and
+        `bucket_end` based on the observed hourly bucket start timestamp. The
+        most recent bucket is ignored for a short delay after its end time so
+        partially updated API data does not temporarily replace the latest value
+        with zero.
+        """
+        if not isinstance(detailed_consumption, dict):
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        data = detailed_consumption.get("data") or []
+        period = detailed_consumption.get("period") or {}
+
+        if not isinstance(data, list):
+            data = []
+
+        grouped_by_timestamp: dict[Any, dict[str, Any]] = {}
+        bucket_cutoff_datetime = dt_util.now() - timedelta(
+            minutes=EXTENDED_CONSUMPTION_BUCKET_DELAY_MINUTES
+        )
+
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+
+            timestamp = item.get("ts")
+            value = item.get("value")
+            water_type = item.get("type") or "unknown"
+            timestamp_datetime = self._timestamp_to_datetime(timestamp)
+            bucket_start_datetime = timestamp_datetime
+            bucket_end_datetime = (
+                bucket_start_datetime + timedelta(hours=1)
+                if bucket_start_datetime
+                else None
+            )
+
+            if bucket_end_datetime and bucket_end_datetime > bucket_cutoff_datetime:
+                continue
+
             try:
-                for key_part in self.entity_description.key.split("."):
-                    if value is None:
-                        break
-                    value = value.get(key_part)
-            except AttributeError:
-                value = None
-            self._attr_native_value = value
+                value_liters = float(value)
+            except (TypeError, ValueError):
+                continue
+
+            grouped = grouped_by_timestamp.setdefault(
+                timestamp,
+                {
+                    "ts": timestamp,
+                    "datetime": timestamp_datetime.isoformat()
+                    if timestamp_datetime
+                    else None,
+                    "bucket_start": bucket_start_datetime.isoformat()
+                    if bucket_start_datetime
+                    else None,
+                    "bucket_end": bucket_end_datetime.isoformat()
+                    if bucket_end_datetime
+                    else None,
+                    "hot_liter": 0.0,
+                    "cold_liter": 0.0,
+                    "unknown_liter": 0.0,
+                    "total_liter": 0.0,
+                },
+            )
+
+            if water_type == "hot":
+                grouped["hot_liter"] += value_liters
+            elif water_type == "cold":
+                grouped["cold_liter"] += value_liters
+            else:
+                grouped["unknown_liter"] += value_liters
+
+            grouped["total_liter"] += value_liters
+
+        hourly_total = [
+            {
+                **item,
+                "hot_liter": round(item["hot_liter"], 3),
+                "cold_liter": round(item["cold_liter"], 3),
+                "unknown_liter": round(item["unknown_liter"], 3),
+                "total_liter": round(item["total_liter"], 3),
+            }
+            for item in sorted(
+                grouped_by_timestamp.values(), key=lambda item: item["ts"] or 0
+            )
+        ]
+
+        hourly_total = hourly_total[-24:]
+        latest_total = hourly_total[-1]["total_liter"] if hourly_total else None
+        self._attr_native_value = latest_total
+        self._attr_extra_state_attributes = {
+            "hourly_total": hourly_total,
+            "period": period,
+            "raw_row_count": len(data),
+            "hourly_total_count": len(hourly_total),
+            "bucket_delay_minutes": EXTENDED_CONSUMPTION_BUCKET_DELAY_MINUTES,
+        }


### PR DESCRIPTION
## Summary

Add support for timestamped hourly consumption and additional diagnostic sensors using Quandify API endpoints.

## Changes

* Add API helpers for detailed consumption, leak status and firmware version endpoints.
* Fetch optional extended consumption and diagnostic data on the normal coordinator polling interval.
* Use Home Assistant’s configured time zone for consumption requests.
* Expose sensors for latest hourly consumption, leak state, leak mean flow rate, leak status timestamp, current firmware and latest firmware.
* Group detailed consumption rows into hourly totals with bucket_start and bucket_end attributes.
* Treat hourly consumption timestamps as bucket starts based on observed API behavior with truncate=hour.
* Delay use of the newest hourly bucket to avoid temporarily exposing partially updated API data.
* Keep raw API timestamps unchanged and avoid storing raw consumption rows as state attributes to reduce recorder load.

## Testing

Tested locally with a Water Grip device.

* Existing sensors continue to update.
* New sensors are created and update after restart.
* Hourly consumption updates correctly after completed hourly buckets.
* Multiple restarts and hourly transitions tested.
* Hourly bucket data aligns with Quandify app behavior around day boundaries.
* No recorder warnings observed from oversized state attributes.